### PR TITLE
Improve gallery synchronization and media handling

### DIFF
--- a/back/jest.config.cjs
+++ b/back/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {},
+  extensionsToTreatAsEsm: ['.js']
+};

--- a/back/models/Service.js
+++ b/back/models/Service.js
@@ -63,6 +63,10 @@ const serviceSchema = new mongoose.Schema({
     enum: ['homme', 'femme', 'enfant', 'adolescent', 'senior'],
     default: 'femme'
   }],
+  images: {
+    type: [String],
+    default: []
+  },
   examplePhotos: {
     type: [String],
     default: []

--- a/back/routes/coiffeurs.js
+++ b/back/routes/coiffeurs.js
@@ -4,6 +4,7 @@ import Service from '../models/Service.js';
 import { auth } from '../middleware/auth.js';
 import multer from 'multer';
 import { getCoiffeurAvailableSlots } from '../services/slotService.js';
+import { aggregateGalleryFromServices } from '../utils/galleryUtils.js';
 // photoService removed - simplified photo system
 
 const router = express.Router();
@@ -312,77 +313,17 @@ router.get('/:id/gallery-sync', async (req, res) => {
     const { id } = req.params;
 
     const services = await Service.find({ coiffeur: id, isActive: true }).select(
-      'name price duration category description gallery examplePhotos'
+      'name price duration category description gallery examplePhotos images createdAt'
     );
 
-    if (!services.length) {
-      return res.json({
-        success: true,
-        coiffeurId: id,
-        count: 0,
-        deduplicatedFrom: 0,
-        items: []
-      });
-    }
-
-    const aggregatedItems = services.flatMap((service) => {
-      const baseInfo = {
-        serviceId: service._id,
-        serviceName: service.name,
-        servicePrice: service.price,
-        serviceDuration: service.duration,
-        serviceCategory: service.category,
-        serviceDescription: service.description
-      };
-
-      const galleryItems = (service.gallery || []).map((media, index) => ({
-        id: `${service._id}-gallery-${index}`,
-        origin: 'gallery',
-        mediaUrl: media.mediaUrl,
-        mediaType: media.mediaType,
-        caption: media.caption,
-        tags: media.tags,
-        likes: media.likes,
-        createdAt: media.createdAt,
-        ...baseInfo
-      }));
-
-      const examplePhotoItems = (service.examplePhotos || []).map((photoUrl, index) => ({
-        id: `${service._id}-example-${index}`,
-        origin: 'examplePhotos',
-        mediaUrl: photoUrl,
-        mediaType: 'image',
-        caption: baseInfo.serviceDescription,
-        tags: [],
-        likes: 0,
-        createdAt: service.createdAt,
-        ...baseInfo
-      }));
-
-      return [...galleryItems, ...examplePhotoItems];
-    });
-
-    const seen = new Set();
-    const dedupedItems = aggregatedItems.filter((item) => {
-      if (!item.mediaUrl) {
-        return false;
-      }
-
-      const key = `${item.mediaUrl}`;
-      if (seen.has(key)) {
-        return false;
-      }
-
-      seen.add(key);
-      return true;
-    });
+    const aggregated = aggregateGalleryFromServices(services);
 
     return res.json({
       success: true,
       coiffeurId: id,
-      count: dedupedItems.length,
-      deduplicatedFrom: aggregatedItems.length,
-      items: dedupedItems
+      count: aggregated.count,
+      deduplicatedFrom: aggregated.deduplicatedFrom,
+      items: aggregated.items
     });
   } catch (error) {
     console.error('Erreur lors de la synchronisation de la galerie coiffeur :', error);

--- a/back/utils/galleryUtils.js
+++ b/back/utils/galleryUtils.js
@@ -1,0 +1,95 @@
+export const normalizeServiceMedia = (service) => {
+  const baseInfo = {
+    serviceId: service._id?.toString?.() ?? '',
+    serviceName: service.name,
+    servicePrice: service.price,
+    serviceDuration: service.duration,
+    serviceCategory: service.category,
+    serviceDescription: service.description
+  };
+
+  const galleryItems = (service.gallery || [])
+    .map((media, index) => {
+      const mediaUrl = media?.mediaUrl || media?.photoUrl || media;
+      return mediaUrl
+        ? {
+            id: `${baseInfo.serviceId}-gallery-${index}`,
+            origin: 'gallery',
+            mediaUrl,
+            mediaType: media.mediaType || 'image',
+            caption: media.caption || baseInfo.serviceDescription,
+            tags: media.tags || [],
+            likes: media.likes ?? 0,
+            createdAt: media.createdAt || service.createdAt,
+            ...baseInfo
+          }
+        : null;
+    })
+    .filter(Boolean);
+
+  const imageItems = (service.images || [])
+    .map((url, index) =>
+      url
+        ? {
+            id: `${baseInfo.serviceId}-images-${index}`,
+            origin: 'images',
+            mediaUrl: url,
+            mediaType: 'image',
+            caption: baseInfo.serviceDescription,
+            tags: [],
+            likes: service.likes ?? 0,
+            createdAt: service.createdAt,
+            ...baseInfo
+          }
+        : null
+    )
+    .filter(Boolean);
+
+  const examplePhotoItems = (service.examplePhotos || [])
+    .map((photoUrl, index) =>
+      photoUrl
+        ? {
+            id: `${baseInfo.serviceId}-example-${index}`,
+            origin: 'examplePhotos',
+            mediaUrl: photoUrl,
+            mediaType: 'image',
+            caption: baseInfo.serviceDescription,
+            tags: [],
+            likes: service.likes ?? 0,
+            createdAt: service.createdAt,
+            ...baseInfo
+          }
+        : null
+    )
+    .filter(Boolean);
+
+  return [...galleryItems, ...imageItems, ...examplePhotoItems];
+};
+
+export const aggregateGalleryFromServices = (services = []) => {
+  const aggregatedItems = services.flatMap(normalizeServiceMedia);
+
+  const seen = new Set();
+  const dedupedItems = aggregatedItems.filter((item) => {
+    const url = item.mediaUrl?.trim();
+
+    if (!url) {
+      return false;
+    }
+
+    if (seen.has(url)) {
+      return false;
+    }
+
+    seen.add(url);
+    return true;
+  });
+
+  return {
+    items: dedupedItems,
+    count: dedupedItems.length,
+    deduplicatedFrom: aggregatedItems.length
+  };
+};
+
+export default aggregateGalleryFromServices;

--- a/back/utils/galleryUtils.test.js
+++ b/back/utils/galleryUtils.test.js
@@ -1,0 +1,72 @@
+import { aggregateGalleryFromServices, normalizeServiceMedia } from './galleryUtils.js';
+
+describe('galleryUtils', () => {
+  const baseService = {
+    _id: 'service-1',
+    name: 'Coupe test',
+    description: 'Description',
+    price: 50,
+    duration: 30,
+    category: 'coupe',
+    createdAt: new Date('2024-01-01'),
+    likes: 2
+  };
+
+  it('agrège et déduplique les médias examplePhotos, gallery et images', () => {
+    const services = [
+      {
+        ...baseService,
+        gallery: [
+          { mediaUrl: '/img/a.jpg', mediaType: 'image' },
+          { mediaUrl: '/img/b.jpg', mediaType: 'image' }
+        ],
+        examplePhotos: ['/img/a.jpg', '/img/c.jpg'],
+        images: ['/img/d.jpg', '']
+      }
+    ];
+
+    const aggregated = aggregateGalleryFromServices(services);
+
+    expect(aggregated.items).toHaveLength(3);
+    expect(aggregated.deduplicatedFrom).toBe(5);
+    const origins = aggregated.items.map((item) => item.origin).sort();
+    expect(origins).toEqual(['examplePhotos', 'gallery', 'images']);
+  });
+
+  it('met à jour la galerie après modification des médias', () => {
+    const service = {
+      ...baseService,
+      examplePhotos: ['/img/a.jpg'],
+      gallery: [],
+      images: []
+    };
+
+    const initialMedia = normalizeServiceMedia(service);
+    expect(initialMedia.map((item) => item.mediaUrl)).toContain('/img/a.jpg');
+
+    service.examplePhotos = ['/img/b.jpg'];
+    const updatedMedia = normalizeServiceMedia(service);
+    expect(updatedMedia.map((item) => item.mediaUrl)).toEqual(['/img/b.jpg']);
+  });
+
+  it('retire les médias liés à un service supprimé', () => {
+    const services = [
+      {
+        ...baseService,
+        _id: 'service-1',
+        examplePhotos: ['/img/a.jpg']
+      },
+      {
+        ...baseService,
+        _id: 'service-2',
+        examplePhotos: ['/img/b.jpg']
+      }
+    ];
+
+    const aggregated = aggregateGalleryFromServices(services);
+    expect(aggregated.items.map((item) => item.mediaUrl).sort()).toEqual(['/img/a.jpg', '/img/b.jpg']);
+
+    const afterDeletion = aggregateGalleryFromServices(services.filter((s) => s._id === 'service-2'));
+    expect(afterDeletion.items.map((item) => item.mediaUrl)).toEqual(['/img/b.jpg']);
+  });
+});

--- a/front/src/components/Gallery.tsx
+++ b/front/src/components/Gallery.tsx
@@ -27,9 +27,19 @@ interface GalleryImage {
   isLiked?: boolean;
 }
 
-const mapSyncedItemsToGalleryImages = (items: SyncedGalleryItem[]): GalleryImage[] =>
-  items
+const mapSyncedItemsToGalleryImages = (items: SyncedGalleryItem[]): GalleryImage[] => {
+  const seen = new Set<string>();
+
+  return items
     .filter((item) => Boolean(item.mediaUrl))
+    .filter((item) => {
+      const key = item.mediaUrl?.trim();
+      if (!key || seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
     .map((item, index) => ({
       _id: item.id ?? `${item.serviceId ?? 'service'}-${index}`,
       url: item.mediaUrl,
@@ -43,6 +53,7 @@ const mapSyncedItemsToGalleryImages = (items: SyncedGalleryItem[]): GalleryImage
       likes: item.likes,
       isLiked: false
     }));
+};
 
 const Gallery: React.FC<GalleryProps> = ({ coiffeurId, isOwner = false, onServiceBook }) => {
   const isMobile = useIsMobile();
@@ -136,6 +147,7 @@ const Gallery: React.FC<GalleryProps> = ({ coiffeurId, isOwner = false, onServic
       console.log('✅ Services récupérés:', services.length);
       
       const galleryImages: GalleryImage[] = [];
+      const seen = new Set<string>();
       
         // Ajouter UNIQUEMENT les images des services
         services.forEach(service => {
@@ -163,7 +175,9 @@ const Gallery: React.FC<GalleryProps> = ({ coiffeurId, isOwner = false, onServic
           
           if (serviceImages && serviceImages.length > 0) {
             serviceImages.forEach((media: any) => {
-              if (media.url && media.url !== 'undefined' && media.url.trim() !== '') {
+              const key = media.url?.trim();
+              if (key && key !== 'undefined' && !seen.has(key)) {
+                seen.add(key);
                 galleryImages.push({
                   _id: `${service._id}_${media.url}`,
                   url: media.url,

--- a/front/src/components/GalleryHub.tsx
+++ b/front/src/components/GalleryHub.tsx
@@ -39,12 +39,20 @@ interface Service {
     likes: number;
     createdAt: Date;
   }>;
+  images?: string[];
   likes: number;
   views: number;
   popularityScore: number;
   style: string;
   targetAudience: string[];
 }
+
+const hasConsistentMedia = (service: Service) => {
+  const hasGallery = Array.isArray(service.gallery) && service.gallery.some((item) => item?.mediaUrl);
+  const hasImages = Array.isArray(service.images) && service.images.some((url) => Boolean(url));
+  const hasExamples = Array.isArray(service.examplePhotos) && service.examplePhotos.some((url) => Boolean(url));
+  return hasGallery || hasImages || hasExamples;
+};
 
 interface GalleryHubProps {
   className?: string;
@@ -183,10 +191,12 @@ export const GalleryHub: React.FC<GalleryHubProps> = ({ className = "" }) => {
         }
       });
       
+      const mediaReadyServices = allServices.filter(hasConsistentMedia);
+
       if (append) {
-        setServices(prev => [...prev, ...allServices]);
+        setServices(prev => [...prev, ...mediaReadyServices]);
       } else {
-        setServices(allServices);
+        setServices(mediaReadyServices);
       }
       
       // Simuler la fin des données après quelques pages

--- a/front/src/components/ServiceCard.tsx
+++ b/front/src/components/ServiceCard.tsx
@@ -15,6 +15,7 @@ interface ServiceCardProps {
     images?: string[];
     likes?: number;
     isLiked?: boolean;
+    isEditable?: boolean;
   };
   isOwner?: boolean;
   showBookButton?: boolean;
@@ -112,7 +113,7 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
       <div className="flex gap-2">
         {isOwner ? (
           <>
-            {onEdit && (
+            {onEdit && service.isEditable !== false && (
               <button
                 onClick={() => onEdit(service._id)}
                 className="flex-1 bg-gray-600 text-white px-3 py-2 rounded text-sm hover:bg-black transition-colors"
@@ -120,7 +121,7 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
                 Modifier
               </button>
             )}
-            {onDelete && (
+            {onDelete && service.isEditable !== false && (
               <button
                 onClick={() => onDelete(service._id)}
                 className="flex-1 bg-red-500 text-white px-3 py-2 rounded text-sm hover:bg-red-600 transition-colors"
@@ -128,6 +129,11 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
                 Supprimer
               </button>
               )}
+            {service.isEditable === false && (
+              <span className="flex-1 text-center text-xs text-gray-500 bg-gray-100 px-3 py-2 rounded">
+                Service système
+              </span>
+            )}
           </>
         ) : (
           <>

--- a/front/src/components/ServiceManager.tsx
+++ b/front/src/components/ServiceManager.tsx
@@ -18,10 +18,14 @@ interface Service {
   category: string;
   keywords: string[];
   examplePhotos: string[];
+  images?: string[];
+  gallery?: any[];
   likes: number;
   isLiked?: boolean;
   coiffeur: string;
   isActive: boolean;
+  isSystemService?: boolean;
+  isEditable?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -58,13 +62,20 @@ const ServiceManager: React.FC<ServiceManagerProps> = ({
       setLoading(true);
       const servicesData = await coiffeurService.getCoiffeurServices(coiffeurId);
       // Convertir les données pour inclure les propriétés par défaut
-      const enrichedServices = servicesData.map(service => ({
-        ...service,
-        keywords: service.keywords || [],
-        examplePhotos: service.examplePhotos || [],
-        likes: service.likes || 0,
-        isLiked: service.isLiked || false
-      }));
+      const enrichedServices = servicesData.map(service => {
+        const isSystem = (service as any).isSystemService || (service as any).isSystem;
+        return {
+          ...service,
+          keywords: service.keywords || [],
+          examplePhotos: service.examplePhotos || [],
+          images: (service as any).images || [],
+          gallery: (service as any).gallery || [],
+          likes: service.likes || 0,
+          isLiked: service.isLiked || false,
+          isSystemService: isSystem,
+          isEditable: (service as any).isEditable ?? !isSystem
+        } as Service;
+      });
       setServices(enrichedServices);
     } catch (error) {
       console.error('Error fetching services:', error);
@@ -90,6 +101,12 @@ const ServiceManager: React.FC<ServiceManagerProps> = ({
         await coiffeurService.deleteService(coiffeurId, serviceId);
         setServices(services.filter(s => s._id !== serviceId));
         setSuccessMessage('Service supprimé avec succès !');
+        try {
+          await coiffeurService.syncGallery(coiffeurId);
+          await fetchServices();
+        } catch (error) {
+          console.error('Error syncing gallery after delete:', error);
+        }
         setTimeout(() => setSuccessMessage(null), 3000);
       } catch (error) {
         console.error('Error deleting service:', error);
@@ -110,13 +127,12 @@ const ServiceManager: React.FC<ServiceManagerProps> = ({
         setSuccessMessage('Service ajouté avec succès !');
       }
 
-      // Synchroniser la galerie avec les nouvelles images
-      if (serviceData.examplePhotos && serviceData.examplePhotos.length > 0) {
-        try {
-          await coiffeurService.syncGallery(coiffeurId);
-        } catch (error) {
-          console.error('Error syncing gallery:', error);
-        }
+      // Synchroniser la galerie après toute modification
+      try {
+        await coiffeurService.syncGallery(coiffeurId);
+        await fetchServices();
+      } catch (error) {
+        console.error('Error syncing gallery:', error);
       }
 
       // Fermer le modal et réinitialiser
@@ -137,6 +153,9 @@ const ServiceManager: React.FC<ServiceManagerProps> = ({
                          service.keywords?.some(keyword => keyword.toLowerCase().includes(searchTerm.toLowerCase()));
     return matchesCategory && matchesSearch;
   });
+
+  const editableServices = filteredServices.filter(service => service.isEditable !== false);
+  const systemServices = filteredServices.filter(service => service.isEditable === false || service.isSystemService);
 
   const categories = [
     { value: 'all', label: 'Toutes les catégories' },
@@ -231,14 +250,14 @@ const ServiceManager: React.FC<ServiceManagerProps> = ({
       </div>
 
       {/* Liste des services */}
-      {filteredServices.length === 0 ? (
+      {editableServices.length === 0 && systemServices.length === 0 ? (
         <div className="text-center py-12 bg-fashion-light-gray rounded-xl shadow-lg">
           <div className="text-gray-400 text-6xl mb-4">✂️</div>
           <h3 className="text-xl font-semibold text-gray-700 mb-2">
             {isOwner ? 'Aucun service disponible' : 'Aucun service trouvé'}
           </h3>
           <p className="text-gray-500 mb-6">
-            {isOwner 
+            {isOwner
               ? 'Commencez par ajouter votre premier service pour attirer des clients !'
               : 'Aucun service ne correspond à vos critères de recherche.'
             }
@@ -253,19 +272,50 @@ const ServiceManager: React.FC<ServiceManagerProps> = ({
           )}
         </div>
       ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
-          {filteredServices.map((service) => (
-            <ServiceCard
-              key={service._id}
-              service={service}
-              isOwner={isOwner}
-              onEdit={() => handleEditService(service)}
-              onDelete={() => handleDeleteService(service._id)}
-              onBook={onServiceBook ? () => onServiceBook(service._id) : undefined}
-              onLike={onServiceLike ? () => onServiceLike(service._id) : undefined}
-              showBookButton={onServiceBook !== undefined}
-            />
-          ))}
+        <div className="space-y-10">
+          {editableServices.length > 0 && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-800">Services éditables</h3>
+                <span className="text-sm text-gray-500">{editableServices.length} service(s)</span>
+              </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+                {editableServices.map((service) => (
+                  <ServiceCard
+                    key={service._id}
+                    service={service}
+                    isOwner={isOwner}
+                    onEdit={service.isEditable === false ? undefined : () => handleEditService(service)}
+                    onDelete={service.isEditable === false ? undefined : () => handleDeleteService(service._id)}
+                    onBook={onServiceBook ? () => onServiceBook(service._id) : undefined}
+                    onLike={onServiceLike ? () => onServiceLike(service._id) : undefined}
+                    showBookButton={onServiceBook !== undefined}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {systemServices.length > 0 && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-800">Services système</h3>
+                <span className="text-sm text-gray-500">Lecture seule</span>
+              </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+                {systemServices.map((service) => (
+                  <ServiceCard
+                    key={service._id}
+                    service={{ ...service, isEditable: false }}
+                    isOwner={isOwner}
+                    onBook={onServiceBook ? () => onServiceBook(service._id) : undefined}
+                    onLike={onServiceLike ? () => onServiceLike(service._id) : undefined}
+                    showBookButton={onServiceBook !== undefined}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/front/src/services/api/coiffeurs.ts
+++ b/front/src/services/api/coiffeurs.ts
@@ -43,7 +43,7 @@ export interface SearchQuery {
 
 export interface SyncedGalleryItem {
   id?: string;
-  origin?: 'gallery' | 'examplePhotos';
+  origin?: 'gallery' | 'examplePhotos' | 'images';
   mediaUrl: string;
   mediaType?: 'image' | 'video';
   caption?: string;


### PR DESCRIPTION
## Summary
- aggregate service media (gallery, images, example photos) through a shared utility and expose deduplicated sync output
- add optional service images schema support and frontend handling that distinguishes editable vs system services
- filter gallery displays to media-ready services and add tests covering gallery aggregation through create/edit/delete scenarios

## Testing
- npm test -- --runInBand *(fails: jest binary unavailable without registry access; install blocked by 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919fa5a01788331a600e04e7fa732d3)